### PR TITLE
Make option to show turns on the main screen.

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -1173,6 +1173,8 @@ EX void initConfig() {
 
   param_i(min_cells_drawn, "min_cells_drawn");
 
+  param_b(show_turns, "show_turns", false)
+  -> editable("show turn count", 'T');
   param_i(menu_darkening, "menu_darkening", 2)
   -> editable(0, 8, 1, "menu map darkening", "A larger number means darker game map in the background. Set to 8 to disable the background.", 'd')
   -> set_sets([] { dialog::bound_low(0); dialog::bound_up(8); dialog::get_di().dialogflags |= sm::DARKEN; });
@@ -2443,6 +2445,7 @@ EX void configureInterface() {
       };
     });
 
+  add_edit(show_turns);
   add_edit(menu_darkening);
   add_edit(centered_menus);
   add_edit(startanims::enabled);

--- a/graph.cpp
+++ b/graph.cpp
@@ -5672,6 +5672,7 @@ EX bool just_refreshing;
 
 EX int menu_darkening = 2;
 EX bool centered_menus = false;
+EX bool show_turns = false;
 
 EX void gamescreen() {
 
@@ -5805,7 +5806,8 @@ EX void normalscreen() {
     displayButton(vid.xres-8, vid.yres-vid.fsize, XLAT("(ESC) tour menu"), SDLK_ESCAPE, 16);
 #endif
   else
-    displayButton(vid.xres-8, vid.yres-vid.fsize, XLAT("(v) menu"), 'v', 16);
+    displayButton(vid.xres-8, vid.yres-vid.fsize,
+        show_turns ? "t:" + its(turncount) : XLAT("(v) menu"), 'v', 16);
   keyhandler = handleKeyNormal;
 
   if(!playerfound && !anims::any_on() && !sphere && !no_find_player && mapeditor::drawplayer)


### PR DESCRIPTION
"Conservative" version that shows the turncount only where it'd formerly show the "(v) menu" string.  No chance of breaking on mobile because it won't show on mobile at all.  :(